### PR TITLE
fix linux install script

### DIFF
--- a/script/ci/linux/install.sh
+++ b/script/ci/linux/install.sh
@@ -6,7 +6,7 @@ OFXFBX_ROOT=$DIR/../../..
 
 mkdir -p /tmp/fbx20195_fbxsdk_linux
 cd /tmp/fbx20195_fbxsdk_linux
-wget https://www.autodesk.com/content/dam/autodesk/www/adn/fbx/20195/fbx20195_fbxsdk_linux.tar.gz
+wget --user-agent="openFrameworks" https://www.autodesk.com/content/dam/autodesk/www/adn/fbx/20195/fbx20195_fbxsdk_linux.tar.gz
 tar xvfz fbx20195_fbxsdk_linux.tar.gz
 
 # install in temp directory (not system wide)


### PR DESCRIPTION
we need to now send a user agent in our wget request, otherwise there is a 403 Forbidden Access error.

fix #22 

tested on Linux Debian 11, should be the same for all Linux distributions